### PR TITLE
A touch of optimization

### DIFF
--- a/ray.cabal
+++ b/ray.cabal
@@ -37,6 +37,7 @@ library
                        Ray.Math
                          Ray.Math.Intersection
                          Ray.Math.Transform
+                         Ray.Math.Vector
 
   build-depends:       base ^>= 4.13
                      , text ^>= 1.2

--- a/src/Ray/Lighting.hs
+++ b/src/Ray/Lighting.hs
@@ -1,13 +1,15 @@
+{-# LANGUAGE Strict #-}
 module Ray.Lighting
   ( calcColor
   ) where
 
 import Foreign.C.Types (CFloat)
-import SDL (V3(..), V4(..), dot, norm)
+import SDL (V3(..), V4(..))
 
 import Ray.Scene.Types (Light(..))
 import qualified Ray.Scene.Types as Light (intensity)
 import Ray.Math.Intersection (Intersection(..))
+import Ray.Math.Vector (dot, norm)
 import Ray.Color (Color)
 import qualified Ray.Color as Color
 

--- a/src/Ray/Lighting.hs
+++ b/src/Ray/Lighting.hs
@@ -3,7 +3,7 @@ module Ray.Lighting
   ) where
 
 import Foreign.C.Types (CFloat)
-import SDL (V3(..), dot, norm)
+import SDL (V3(..), V4(..), dot, norm)
 
 import Ray.Scene.Types (Light(..))
 import qualified Ray.Scene.Types as Light (intensity)
@@ -15,9 +15,15 @@ calcColor :: CFloat -> [Light] -> Maybe Intersection -> Color
 calcColor ambient lights = maybe Color.bg (applyLights ambient lights)
 
 applyLights :: CFloat -> [Light] -> Intersection -> Color
-applyLights ambient lights Intersection{..} =
-  let intensity = ambient + computeAll iPoint iNormal lights
-   in round . (*) intensity . fromIntegral <$> iColor
+applyLights ambient lights Intersection{..} = transform iColor
+  where
+    transform (V4 r g b a) =
+      let intensity = ambient + computeAll iPoint iNormal lights
+          r1 = round . (*) intensity $ fromIntegral r
+          g1 = round . (*) intensity $ fromIntegral g
+          b1 = round . (*) intensity $ fromIntegral b
+          a1 = round . (*) intensity $ fromIntegral a
+       in V4 r1 g1 b1 a1
 
 computeAll :: V3 CFloat -> V3 CFloat -> [Light] -> CFloat
 computeAll p n = sum . map (compute p n)

--- a/src/Ray/Lighting.hs
+++ b/src/Ray/Lighting.hs
@@ -9,7 +9,7 @@ import SDL (V3(..), V4(..))
 import Ray.Scene.Types (Light(..))
 import qualified Ray.Scene.Types as Light (intensity)
 import Ray.Math.Intersection (Intersection(..))
-import Ray.Math.Vector (dot, norm)
+import Ray.Math.Vector (dot, minus, norm, plus, scaledBy)
 import Ray.Color (Color)
 import qualified Ray.Color as Color
 
@@ -21,10 +21,11 @@ applyLights ambient lights Intersection{..} = transform iColor
   where
     transform (V4 r g b a) =
       let intensity = ambient + computeAll iPoint iNormal lights
-          r1 = round . (*) intensity $ fromIntegral r
-          g1 = round . (*) intensity $ fromIntegral g
-          b1 = round . (*) intensity $ fromIntegral b
-          a1 = round . (*) intensity $ fromIntegral a
+          rint = round $ recip intensity
+          r1 = r `div` rint
+          g1 = g `div` rint
+          b1 = b `div` rint
+          a1 = a `div` rint
        in V4 r1 g1 b1 a1
 
 computeAll :: V3 CFloat -> V3 CFloat -> [Light] -> CFloat
@@ -36,7 +37,7 @@ compute p n light =
       d = n `dot` l
    in clamp d $ (Light.intensity light * d) / (norm n * norm l)
   where
-    dir (PointLight _ pos) = pos - p
+    dir (PointLight _ pos) = pos `minus` p
     dir (DirectionalLight _ d) = d
 
     clamp d x

--- a/src/Ray/Math.hs
+++ b/src/Ray/Math.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 module Ray.Math
   ( traceRay
 
@@ -9,7 +10,7 @@ import Data.Function (on)
 import Data.List (foldl', minimumBy)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Foreign.C.Types (CFloat)
-import SDL (V3(..), distance)
+import SDL (V3(..))
 
 import Ray.Scene.Types (Scene(..), Camera(..))
 import Ray.Color (Color)
@@ -17,6 +18,7 @@ import Ray.Lighting (calcColor)
 
 import Ray.Math.Intersection (Intersection(..), intersect)
 import Ray.Math.Transform (project)
+import Ray.Math.Vector (distance)
 
 -- | Computes the intersection of the ray with every sphere,
 -- and returns the color of the sphere at the nearest intersection

--- a/src/Ray/Math.hs
+++ b/src/Ray/Math.hs
@@ -5,10 +5,9 @@ module Ray.Math
   , module Ray.Math.Intersection
   ) where
 
-import Data.Maybe (fromMaybe)
 import Data.Function (on)
 import Data.List (foldl', minimumBy)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Foreign.C.Types (CFloat)
 import SDL (V3(..), distance)
 

--- a/src/Ray/Math/Vector.hs
+++ b/src/Ray/Math/Vector.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE Strict #-}
+module Ray.Math.Vector
+  ( distance
+  , dot
+  , minus
+  , norm
+  , plus
+  , scaledBy
+  , signorm
+  , quadrance
+  ) where
+
+
+import Foreign.C.Types (CFloat)
+import SDL (V3(..))
+
+distance :: V3 CFloat -> V3 CFloat -> CFloat
+distance v1 v2 = norm $ v2 `minus` v1
+{-# INLINE distance #-}
+
+dot :: V3 CFloat -> V3 CFloat -> CFloat
+dot (V3 x1 y1 z1) (V3 x2 y2 z2) = x1*x2 + y1*y2 + z1*z2
+{-# INLINE dot #-}
+
+minus :: V3 CFloat -> V3 CFloat -> V3 CFloat
+minus (V3 x1 y1 z1) (V3 x2 y2 z2) = V3 (x2 - x1) (y2 - y1) (z2 - z1)
+{-# INLINE minus #-}
+
+norm :: V3 CFloat -> CFloat
+norm (V3 x y z) = sqrt $ x*x + y*y + z*z
+{-# INLINE norm #-}
+
+plus :: V3 CFloat -> V3 CFloat -> V3 CFloat
+plus (V3 x1 y1 z1) (V3 x2 y2 z2) = V3 (x2 + x1) (y2 + y1) (z2 + z1)
+{-# INLINE plus #-}
+
+scaledBy :: V3 CFloat -> CFloat -> V3 CFloat
+scaledBy (V3 x y z) s = V3 (x*s) (y*s) (z*s)
+{-# INLINE scaledBy #-}
+
+signorm :: V3 CFloat -> V3 CFloat
+signorm v@(V3 x y z) = V3 (x/n) (y/n) (z/n)
+  where n = norm v
+{-# INLINE signorm #-}
+
+quadrance :: V3 CFloat -> CFloat
+quadrance (V3 x y z) = x*x + y*y + z*z
+
+{-# INLINE quadrance #-}


### PR DESCRIPTION
Unfortunately had to return (and expand) manual implementation of vector operations on `V3`. That's because instances in `Linear` are completely polymorphic and cannot be specialized across libraries. SDL `no-linear` Cabal flag is supposed to fix exactly this issue but I failed to enable it.